### PR TITLE
Added the ability to bump a patch version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+artifacts/
+.DS_STORE
+.*.swp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thank you for considering contributing! There are many ways you can help.
+
+## Issues
+
+File an issue if you think you've found a bug. Be sure to describe
+
+1. How can it be reproduced?
+2. What did you expect?
+3. What actually occurred?
+4. Version, platform, etc. if possibly relevant.
+
+## Docs
+
+Documentation, READMEs, and examples are extremely important. Please help improve them and if you find a typo or notice a problem, please send a fix or say something.
+
+## Submitting Patches
+
+Patches for fixes, features, and improvements are accepted through pull requests.
+
+* Write good commit messages, in the present tense! (Add X, not Added X). Short title, blank line, bullet points if needed. Capitalize the first letter of the title or bullet item. No punctuation in the title.
+* Code must pass lint and style checks.
+* All external methods must be documented.
+* Include tests to improve coverage and prevent regressions.
+* Squash changes into a single commit per feature/fix. Ask if you're unsure how to discretize your work.
+
+Please ask before embarking on a large improvement so you're not disappointed if it does not align with the goals of the project or owner(s).
+
+## Feature Requests
+
+Make the case for a feature via an issue with a good title. The feature should be discussed and given a target inclusion milestone or closed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2016 Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Yahoo! Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# gitversion
+# GitVersion
+[![Build Status][wercker-image]][wercker-url] [![Open Issues][issues-image]][issues-url]
+
+> A helper for bumping versions via git tags.
+
+## Usage
+
+```bash
+gitversion --prefix v bump patch
+```
+
+## Testing
+
+```bash
+go test ./...
+```
+
+## License
+
+Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
+
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/gitversion.svg
+[issues-url]: https://github.com/screwdriver-cd/gitversion/issues
+[wercker-image]: https://app.wercker.com/status/28e7d21d5c6bfe687a26689ea48e53a7
+[wercker-url]: https://app.wercker.com/project/bykey/28e7d21d5c6bfe687a26689ea48e53a7

--- a/git/git.go
+++ b/git/git.go
@@ -1,0 +1,50 @@
+package git
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+)
+
+var execCommand = exec.Command
+
+// Tags returns the list of git tags as a string slice
+func Tags() ([]string, error) {
+	cmd := execCommand("git", "tag")
+	outReader, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("fetching git tags: %v", err)
+	}
+
+	var lines []string
+	scanner := bufio.NewScanner(outReader)
+	go func() {
+		for scanner.Scan() {
+			line := scanner.Text()
+			lines = append(lines, line)
+		}
+	}()
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("starting git command: %v", err)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return nil, fmt.Errorf("waiting for git command: %v", err)
+	}
+
+	return lines, nil
+}
+
+// Tag calls git to create a new tag from a string
+func Tag(tag string) error {
+	cmd := execCommand("git", "tag", tag)
+	_, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("tagging the commit in git: %v", err)
+	}
+
+	return nil
+}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -1,0 +1,102 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+type execFunc func(command string, args ...string) *exec.Cmd
+
+func getFakeExecCommand(validator func(string, ...string)) execFunc {
+	return func(command string, args ...string) *exec.Cmd {
+		validator(command, args...)
+		return fakeExecCommand(command, args...)
+	}
+}
+
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func TestTags(t *testing.T) {
+	expected := []string{
+		"v1.0.1",
+		"v2.0.1",
+		"v1.2.1",
+		"v1.4.3",
+	}
+
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	tags, err := Tags()
+
+	if err != nil {
+		t.Errorf("Tags() error = %q, should be nil", err)
+	}
+
+	if len(expected) != len(tags) {
+		t.Errorf("len(Tags()) = %v, want %v", len(tags), len(expected))
+	}
+
+	for i, tag := range tags {
+		if expected[i] != tag {
+			t.Errorf("Tags()[%v] = %v, want %v", i, tag, expected[i])
+		}
+	}
+}
+
+func TestTag(t *testing.T) {
+	execCommand = getFakeExecCommand(func(cmd string, args ...string) {
+		if len(args) != 2 {
+			t.Errorf("wrong arguments supplied to git tag: %v", args)
+		}
+		want := "v10.10.10"
+		if args[1] != want {
+			t.Errorf("Tag received the wrong tag: %q, want %q", args[1], want)
+		}
+	})
+	defer func() { execCommand = exec.Command }()
+
+	Tag("v10.10.10")
+}
+
+// This is a fake test for mocking out exec calls.
+// See https://golang.org/src/os/exec/exec_test.go and
+// https://npf.io/2015/06/testing-exec-command/ for more info
+func TestHelperProcess(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	args := os.Args[3:] // Should become something lke ["git", "tag"]
+	if len(args) >= 2 && args[0] == "git" && args[1] == "tag" {
+		if len(args) == 2 {
+			tags := []string{
+				"v1.0.1",
+				"v2.0.1",
+				"v1.2.1",
+				"v1.4.3",
+			}
+			for _, tag := range tags {
+				fmt.Println(tag)
+			}
+			return
+		}
+
+		if len(args) == 3 {
+			return
+		}
+
+		os.Exit(255)
+	}
+
+	os.Exit(255)
+}

--- a/gitversion.go
+++ b/gitversion.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"github.com/screwdriver-cd/gitversion/git"
+	"github.com/screwdriver-cd/gitversion/version"
+	"github.com/urfave/cli"
+	"os"
+	"sort"
+)
+
+func bumpPatch(prefix string) error {
+	v, err := latestVersion(prefix)
+	if err != nil {
+		return fmt.Errorf("bumping patch version %v: %v", v, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Bumping patch for version %v\n", v)
+	v.Patch++
+	if err = gitTag(fmt.Sprintf("%v%v", prefix, v.String())); err != nil {
+		return fmt.Errorf("creating new tag %v", v)
+	}
+	fmt.Println(v)
+	return nil
+}
+
+var gitTags = git.Tags
+var gitTag = git.Tag
+
+func latestVersion(prefix string) (v version.Version, err error) {
+	versions, err := versions(prefix)
+	if err != nil {
+		return v, err
+	}
+
+	sort.Sort(sort.Reverse(&versions))
+	return versions[0], err
+}
+
+func versions(prefix string) (version.List, error) {
+	versions := version.List{}
+	tags, err := gitTags()
+	if err != nil {
+		return nil, fmt.Errorf("fetching git tags: %v", err)
+	}
+
+	for _, tag := range tags {
+		if len(tag) <= len(prefix) || tag[:len(prefix)] != prefix {
+			continue
+		}
+		tag = tag[len(prefix):]
+		v, err := version.FromString(tag)
+		if err != nil {
+			continue
+		}
+		versions = append(versions, v)
+	}
+
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no valid version tags found")
+	}
+	return versions, nil
+}
+
+func main() {
+	var prefix string
+
+	app := cli.NewApp()
+	app.Name = "gitversion"
+	app.Usage = "manage versions using git tags."
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "prefix",
+			Usage:       "set a prefix for the tag name (e.g. v1.0.0)",
+			Destination: &prefix,
+		},
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name:    "bump",
+			Aliases: []string{"b"},
+			Usage:   "increment the version and create a new git tag",
+			Subcommands: []cli.Command{
+				{
+					Name:  "patch",
+					Usage: "bump the patch version",
+					Action: func(c *cli.Context) error {
+						if err := bumpPatch(prefix); err != nil {
+							fmt.Fprintf(os.Stderr, "Error: %v", err)
+							return err
+						}
+						return nil
+					},
+				},
+			},
+		},
+	}
+
+	app.Run(os.Args)
+}

--- a/gitversion_test.go
+++ b/gitversion_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"github.com/screwdriver-cd/gitversion/git"
+	"testing"
+)
+
+func fakeGitTags() ([]string, error) {
+	return []string{
+		"1.0.1",
+		"2.0.1",
+		"1.2.1",
+		"latest",
+		"stable",
+		"1.4.3",
+		"2.1.2",
+	}, nil
+}
+
+func TestVersions(t *testing.T) {
+	expected := []string{
+		"1.0.1",
+		"2.0.1",
+		"1.2.1",
+		"1.4.3",
+		"2.1.2",
+	}
+
+	gitTags = fakeGitTags
+	defer func() { gitTags = git.Tags }()
+
+	v, err := versions("")
+
+	if err != nil {
+		t.Errorf("versions() error = %v, should be nil", err)
+	}
+
+	if len(expected) != len(v) {
+		t.Fatalf("len(Versions()) = %v, want %v", len(v), len(expected))
+	}
+
+	for i, version := range v {
+		if expected[i] != version.String() {
+			t.Errorf("Versions()[%v] = %v, want %v", i, version, expected[i])
+		}
+	}
+}
+
+func TestNoVersions(t *testing.T) {
+	gitTags = func() ([]string, error) {
+		return []string{}, nil
+	}
+	defer func() { gitTags = git.Tags }()
+
+	v, err := versions("")
+	if err == nil {
+		t.Errorf("error value for an empty version list should be non-nil")
+	}
+	if len(v) != 0 {
+		t.Errorf("Expected empty version.List, got: %v", v)
+	}
+}
+
+func TestLatestVersion(t *testing.T) {
+	gitTags = fakeGitTags
+	defer func() { gitTags = git.Tags }()
+
+	want := "2.1.2"
+
+	latest, err := latestVersion("")
+	if err != nil {
+		t.Errorf("Unexpected error from latestVersion(): %v", err)
+	}
+	if latest.String() != want {
+		t.Errorf("latestVersion() = %v, want %v", latest, want)
+	}
+}
+
+func TestBumpPatch(t *testing.T) {
+	expected := "1.1.2"
+	gitTag = func(tag string) error {
+		if tag != expected {
+			t.Errorf("git.Tag() called with %v, want %v", tag, expected)
+		}
+		return nil
+	}
+
+	gitTags = func() ([]string, error) {
+		return []string{"1.1.1", "0.1.1"}, nil
+	}
+	defer func() { gitTags = git.Tags }()
+
+	bumpPatch("")
+}
+
+func TestPrefix(t *testing.T) {
+	expected := "2.1.0"
+	gitTags = func() ([]string, error) {
+		return []string{
+			"bigPrefix2.1.0",
+			"v2.2.0",
+			"2.3.0",
+		}, nil
+	}
+
+	latest, err := latestVersion("bigPrefix")
+	if err != nil {
+		t.Errorf("unexpected error from latestVersion(): %v", err)
+	}
+
+	if latest.String() != expected {
+		t.Errorf("latestVersion() = %v, want %v", latest, expected)
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,75 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// A Version is a version of the form <major>.<minor>.<patch>
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// Make Builds a Version from major, minor, patch
+func Make(major int, minor int, patch int) Version {
+	return Version{major, minor, patch}
+}
+
+// FromString returns a Version based on a string
+func FromString(v string) (ver Version, err error) {
+	components := strings.Split(v, ".")
+	if len(components) != 3 {
+		return ver, fmt.Errorf("Version must contain 3 components: X.Y.Z")
+	}
+
+	maj, err := strconv.Atoi(components[0])
+	if err != nil {
+		return ver, fmt.Errorf("parsing %s as a version: %v", v, err)
+	}
+
+	min, err := strconv.Atoi(components[1])
+	if err != nil {
+		return ver, fmt.Errorf("parsing %s as a version: %v", v, err)
+	}
+
+	patch, err := strconv.Atoi(components[2])
+	if err != nil {
+		return ver, fmt.Errorf("parsing %s as a version: %v", v, err)
+	}
+	return Version{maj, min, patch}, nil
+}
+
+// String formats Version as <major>.<minor>.<patch>
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// List is a slice of Versions that implements sort.Interface
+type List []Version
+
+// Len implements sort.Interface.Len()
+func (v List) Len() int {
+	return len(v)
+}
+
+// Less implements sort.Interface.Less()
+func (v List) Less(i, j int) bool {
+	if v[i].Major != v[j].Major {
+		return v[i].Major < v[j].Major
+	}
+	if v[i].Minor != v[j].Minor {
+		return v[i].Minor < v[j].Minor
+	}
+	if v[i].Patch != v[j].Patch {
+		return v[i].Patch < v[j].Patch
+	}
+	return false
+}
+
+// Swap implements sort.Interface.Swap()
+func (v List) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,67 @@
+package version
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+func TestFromString(t *testing.T) {
+	var tests = []struct {
+		input string
+		want  Version
+	}{
+		{"1.2.3", Version{1, 2, 3}},
+		{"3.2.1", Version{3, 2, 1}},
+		{"a.b.c", Version{0, 0, 0}},
+	}
+	for _, test := range tests {
+		if v, _ := FromString(test.input); v != test.want {
+			t.Errorf("FromString(%q) = %v, want %v", test.input, v, test.want)
+		}
+	}
+}
+
+func TestBadString(t *testing.T) {
+	v, err := FromString("a.b.c")
+	if err == nil {
+		msg := fmt.Sprintf("err should not be nil. v = %v", v)
+		t.Error(msg)
+	}
+}
+
+func TestToString(t *testing.T) {
+	want := "1.2.3"
+	v, _ := FromString(want)
+	got := fmt.Sprintf("%v", v)
+	if got != want {
+		t.Errorf(`FromString(%q).String() == %q`, want, got)
+	}
+}
+
+func TestVersionListSort(t *testing.T) {
+	var versions = List{
+		{2, 1, 3},
+		{1, 2, 3},
+		{2, 2, 3},
+		{3, 1, 2},
+		{1, 2, 3},
+	}
+	var want = List{
+		{1, 2, 3},
+		{1, 2, 3},
+		{2, 1, 3},
+		{2, 2, 3},
+		{3, 1, 2},
+	}
+
+	sort.Sort(versions)
+	if len(versions) != len(want) {
+		t.Errorf(`error sorting Versions. %v != %v`, versions, want)
+	}
+	for i, v := range versions {
+		if want[i] != v {
+			t.Errorf("Version %v != %v", want[i], v)
+		}
+	}
+}

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,24 @@
+box: google/golang
+
+build:
+  steps:
+    - script:
+      name: go test
+      code: go test ./...
+
+    - script:
+      name: go build
+      code: go build gitversion.go
+
+deploy:
+  steps:
+    - script:
+        name: get version from VERSION file
+        code: export VERSION=$(cat VERSION)
+    - github-create-release:
+        token: $GITHUB_TOKEN
+        tag: v$VERSION
+    - github-upload-asset:
+        token: $GITHUB_TOKEN
+        file: launch
+        content_type: application/octet-stream


### PR DESCRIPTION
- Uses a helper package called "git" to interact with git by shelling out
- Uses a helper for version parsing and sorting
- Only does the patch field right now
- Supports --prefix=v