### PR TITLE
Outputting the prefix with the command's output

### DIFF
--- a/gitversion.go
+++ b/gitversion.go
@@ -13,7 +13,8 @@ import (
 // VERSION gets set by the build script via the LDFLAGS
 var VERSION string
 
-func bumpPatch(prefix string) error {
+// BumpPatch increments the Patch field of the latest version
+func BumpPatch(prefix string) error {
 	v, err := latestVersion(prefix)
 	if err != nil {
 		return fmt.Errorf("bumping patch version %v: %v", v, err)
@@ -24,7 +25,7 @@ func bumpPatch(prefix string) error {
 	if err = gitTag(fmt.Sprintf("%v%v", prefix, v.String())); err != nil {
 		return fmt.Errorf("creating new tag %v", v)
 	}
-	fmt.Println(v)
+	fmt.Fprintf(os.Stdout, "%s%s\n", prefix, v)
 	return nil
 }
 
@@ -95,7 +96,7 @@ func main() {
 					Name:  "patch",
 					Usage: "bump the patch version",
 					Action: func(c *cli.Context) error {
-						if err := bumpPatch(prefix); err != nil {
+						if err := BumpPatch(prefix); err != nil {
 							fmt.Fprintf(os.Stderr, "Error: %v", err)
 							return err
 						}

--- a/gitversion_test.go
+++ b/gitversion_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/screwdriver-cd/gitversion/git"
 	"testing"
+
+	"github.com/screwdriver-cd/gitversion/git"
 )
 
 func fakeGitTags() ([]string, error) {
@@ -90,7 +91,7 @@ func TestBumpPatch(t *testing.T) {
 	}
 	defer func() { gitTags = git.Tags }()
 
-	bumpPatch("")
+	BumpPatch("")
 }
 
 func TestPrefix(t *testing.T) {
@@ -111,4 +112,15 @@ func TestPrefix(t *testing.T) {
 	if latest.String() != expected {
 		t.Errorf("latestVersion() = %v, want %v", latest, expected)
 	}
+}
+
+func ExampleBumpPatch() {
+	gitTags = func() ([]string, error) {
+		return []string{
+			"v2.2.0",
+		}, nil
+	}
+
+	BumpPatch("v")
+	// Output: v2.2.1
 }


### PR DESCRIPTION
This should make it more intuitive to say V=$(gitversion --prefix v ...)