### PR TITLE
fix: Ignoring temporary files so build can pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ artifacts/
 .DS_STORE
 .*.swp
 gitversion
+ci/
+VERSION
 .wercker/


### PR DESCRIPTION
See https://cd.screwdriver.cd/pipelines/16/builds/20896

```
release failed after 0.01s
error
=git is currently in a dirty state:
15:49:58
 ?? VERSION
15:49:58
 ?? ci/
```