### PR TITLE
fix: Trying to ignore the temporary file "VERSION" without the dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gitversion
 ci/
 .wercker/
 coverage.out
+VERSION


### PR DESCRIPTION
I removed this so I could edit the `version/` files, but now it's causing the builds to fail.