### PR TITLE
fix: on error, exit command with a non-zero exit code

### DIFF
--- a/gitversion.go
+++ b/gitversion.go
@@ -239,5 +239,9 @@ func main() {
 
 	app.Action = actionLatest
 
-	app.Run(os.Args)
+	// if Run receives an error, the error message is already printed out to
+	// stderr, but we should exit with an error code
+	if err := app.Run(os.Args); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## Context

Gitversion prints all errors to stderr that are encountered at runtime. However the cli always return successfully. 

## Objective

In the event of an error, the cli should also return a non-zero exit code to notify the caller of an error condition.


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
