### PR TITLE
fix: do not zip binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,8 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-    - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    - format: binary 
+      name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 # Put the packages in the artifacts dir (but it won't eval environment variables)
 dist: /sd/workspace/artifacts/dist


### PR DESCRIPTION
## Context

Binaries are gzipped https://github.com/screwdriver-cd/gitversion/releases and is breaking scripts which downloads these

## Objective

Do not zip binary

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
