### PR TITLE
Added homebrew formula and added parameter --merged (to consider only versions on the current branch).

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,13 @@
+brews:
+  - tap:
+      owner: screwdriver-cd
+      name: gitversion
+    folder: Formula
+    homepage: https://github.com/screwdriver-cd/gitversion
+    description: A helper for bumping versions via git tags.
+    commit_msg_template: "[skip ci] Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    test: |
+      system "#{bin}/gitversion", "--version"
 builds:
   - binary: gitversion
     # Build for Linux and OSX

--- a/README.md
+++ b/README.md
@@ -81,3 +81,18 @@ Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 [issues-url]: https://github.com/screwdriver-cd/screwdriver/issues
 [status-image]: https://cd.screwdriver.cd/pipelines/16/badge
 [status-url]: https://cd.screwdriver.cd/pipelines/16
+
+## Installing locally using homebrew
+
+- prerequisite: install [homebrew](https://homebrew.sh/)
+- Tap gitversion
+
+    ```bash
+    brew tap screwdriver-cd/meta-cli https://github.com/screwdriver-cd/gitversion.git
+    ```
+
+- Install gitversion
+
+    ```bash
+    brew install gitversion
+    ```

--- a/git/git.go
+++ b/git/git.go
@@ -9,11 +9,16 @@ import (
 var execCommand = exec.Command
 
 // Tags returns the list of git tags as a string slice
-func Tags() ([]string, error) {
-	cmd := execCommand("git", "tag")
+func Tags(merged bool) ([]string, error) {
+	args := []string{"tag"}
+	if merged {
+		args = append(args, "--merged")
+	}
+
+	cmd := execCommand("git", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("fetching git tags: %v", err)
+		return nil, fmt.Errorf("fetching git tags: %w", err)
 	}
 
 	trimmed := strings.TrimSpace(string(out))
@@ -26,7 +31,7 @@ func Tag(tag string) error {
 	cmd := execCommand("git", "tag", tag)
 	_, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("tagging the commit in git: %v", err)
+		return fmt.Errorf("tagging the commit in git: %w", err)
 	}
 
 	return nil
@@ -43,7 +48,7 @@ func LastCommit(short bool) (string, error) {
 	}
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("fetching git commit: %v", err)
+		return "", fmt.Errorf("fetching git commit: %w", err)
 	}
 
 	trimmed := strings.TrimSpace(string(out))
@@ -55,7 +60,7 @@ func LastCommitMessage() (string, error) {
 	cmd := execCommand("git", "log", "-1", "--pretty=%B")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("fetching git commit message: %v", err)
+		return "", fmt.Errorf("fetching git commit message: %w", err)
 	}
 
 	trimmed := strings.TrimSpace(string(out))
@@ -66,7 +71,7 @@ func LastCommitMessage() (string, error) {
 func Tagged() (bool, error) {
 	commit, err := LastCommit(false)
 	if err != nil {
-		return false, fmt.Errorf("checking current tag: %v", err)
+		return false, fmt.Errorf("checking current tag: %w", err)
 	}
 	cmd := execCommand("git", "tag", "--contains", commit)
 	t, err := cmd.Output()

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -35,7 +35,7 @@ func TestTags(t *testing.T) {
 	execCommand = fakeExecCommand
 	defer func() { execCommand = exec.Command }()
 
-	tags, err := Tags()
+	tags, err := Tags(false)
 
 	if err != nil {
 		t.Errorf("Tags() error = %q, should be nil", err)

--- a/gitversion_test.go
+++ b/gitversion_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/screwdriver-cd/gitversion/git"
 )
 
-func fakeGitTags() ([]string, error) {
+func fakeGitTags(bool) ([]string, error) {
 	return []string{
 		"1.0.1",
 		"2.0.1",
@@ -30,7 +30,7 @@ func TestVersions(t *testing.T) {
 	gitTags = fakeGitTags
 	defer func() { gitTags = git.Tags }()
 
-	v, err := versions("")
+	v, err := versions("", false)
 
 	if err != nil {
 		t.Errorf("versions() error = %v, should be nil", err)
@@ -48,12 +48,12 @@ func TestVersions(t *testing.T) {
 }
 
 func TestNoVersions(t *testing.T) {
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{}, nil
 	}
 	defer func() { gitTags = git.Tags }()
 
-	v, err := versions("")
+	v, err := versions("", false)
 	if err == nil {
 		t.Errorf("error value for an empty version list should be non-nil")
 	}
@@ -68,7 +68,7 @@ func TestLatestVersion(t *testing.T) {
 
 	want := "2.1.2"
 
-	latest, err := latestVersion("")
+	latest, err := latestVersion("", false)
 	if err != nil {
 		t.Errorf("Unexpected error from latestVersion(): %v", err)
 	}
@@ -87,7 +87,7 @@ func TestBumpAutoTagged(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{"1.1.1", "0.1.1"}, nil
 	}
 	defer func() { gitTags = git.Tags }()
@@ -97,7 +97,7 @@ func TestBumpAutoTagged(t *testing.T) {
 	}
 	defer func() { gitTagged = git.Tagged }()
 
-	err := Bump("", Auto)
+	err := Bump("", Auto, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestBumpAutoMatch(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{"1.1.1", "0.1.1"}, nil
 	}
 	defer func() { gitTags = git.Tags }()
@@ -128,7 +128,7 @@ func TestBumpAutoMatch(t *testing.T) {
 	}
 	defer func() { gitMessage = git.LastCommitMessage }()
 
-	err := Bump("", Auto)
+	err := Bump("", Auto, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestBumpAutoMatchAlternate(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{"1.1.1", "0.1.1"}, nil
 	}
 	defer func() { gitTags = git.Tags }()
@@ -159,7 +159,7 @@ func TestBumpAutoMatchAlternate(t *testing.T) {
 	}
 	defer func() { gitMessage = git.LastCommitMessage }()
 
-	err := Bump("", Auto)
+	err := Bump("", Auto, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestBumpAutoMatchFallback(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{"1.1.1", "0.1.1"}, nil
 	}
 	defer func() { gitTags = git.Tags }()
@@ -190,7 +190,7 @@ func TestBumpAutoMatchFallback(t *testing.T) {
 	}
 	defer func() { gitMessage = git.LastCommitMessage }()
 
-	err := Bump("", Auto)
+	err := Bump("", Auto, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -211,12 +211,12 @@ func TestBumpPreRelease(t *testing.T) {
 	}
 	defer func() { gitCommit = git.LastCommit }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{"1.1.1", "0.1.1"}, nil
 	}
 	defer func() { gitTags = git.Tags }()
 
-	err := Bump("", PreRelease)
+	err := Bump("", PreRelease, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -232,12 +232,12 @@ func TestBumpPatch(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{"1.1.1", "0.1.1"}, nil
 	}
 	defer func() { gitTags = git.Tags }()
 
-	err := Bump("", Patch)
+	err := Bump("", Patch, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -253,12 +253,12 @@ func TestBumpMinor(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{"1.1.1", "0.1.1"}, nil
 	}
 	defer func() { gitTags = git.Tags }()
 
-	err := Bump("", Minor)
+	err := Bump("", Minor, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -274,12 +274,12 @@ func TestBumpMajor(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{"1.1.1", "0.1.1"}, nil
 	}
 	defer func() { gitTags = git.Tags }()
 
-	err := Bump("", Major)
+	err := Bump("", Major, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -295,12 +295,12 @@ func TestBumpWithNoVersions(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{}, nil
 	}
 	defer func() { gitTags = git.Tags }()
 
-	err := Bump("", Patch)
+	err := Bump("", Patch, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -316,12 +316,12 @@ func TestBumpWithBadField(t *testing.T) {
 	}
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{}, nil
 	}
 	defer func() { gitTags = git.Tags }()
 
-	err := Bump("", "foobar")
+	err := Bump("", "foobar", false)
 	if err.Error() != "unknown field type" {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestBumpWithBadField(t *testing.T) {
 
 func TestPrefix(t *testing.T) {
 	expected := "2.1.0"
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{
 			"bigPrefix2.1.0",
 			"v2.2.0",
@@ -338,7 +338,7 @@ func TestPrefix(t *testing.T) {
 	}
 	defer func() { gitTags = git.Tags }()
 
-	latest, err := latestVersion("bigPrefix")
+	latest, err := latestVersion("bigPrefix", false)
 	if err != nil {
 		t.Errorf("unexpected error from latestVersion(): %v", err)
 	}
@@ -355,13 +355,13 @@ func ExampleBump() {
 
 	defer func() { gitTag = git.Tag }()
 
-	gitTags = func() ([]string, error) {
+	gitTags = func(bool) ([]string, error) {
 		return []string{
 			"v2.2.0",
 		}, nil
 	}
 	defer func() { gitTags = git.Tags }()
 
-	Bump("v", Patch)
+	Bump("v", Patch, false)
 	// Output: v2.2.1
 }


### PR DESCRIPTION
## Context

- This adds a homebrew formula via goreleaser
- This adds a `--merged` flag, which is passed to git tag in order to consider only tags on the current branch

## Objective

Allow multiple branches to maintain their own version for teams desiring to keep older minor/major development active with patch-level changes.

## References

- https://goreleaser.com/
- https://github.com/screwdriver-cd/screwdriver/issues/2777
- https://stackoverflow.com/questions/2381665/list-tags-contained-by-a-branch

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
