### PR TITLE
Fix an error that didn't report the underlying error along with its context

### DIFF
--- a/gitversion.go
+++ b/gitversion.go
@@ -98,7 +98,7 @@ func Bump(prefix string, field string, merged bool) error {
 	}
 
 	if err = gitTag(fmt.Sprintf("%v%v", prefix, v.String())); err != nil {
-		return fmt.Errorf("creating new tag %v", v)
+		return fmt.Errorf("creating new tag %v: %w", v, err)
 	}
 	fmt.Fprintf(os.Stdout, "%s%s\n", prefix, v)
 	return nil


### PR DESCRIPTION


## Context

@jithine and I recently spent time debugging an issue with using gitversion that just said error creating new tag and not what the error was - if we had known that the error was related to the tag already existing, finding the root cause would have been straightforward

## Objective

Include the wrapped error in the error being reported when creating a new tag fails.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
