### PR TITLE
modify goreleaser config for version 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,6 @@
+version: 2
 brews:
-  - tap:
-      owner: screwdriver-cd
-      name: gitversion
-    folder: Formula
+  - name: gitversion
     homepage: https://github.com/screwdriver-cd/gitversion
     description: A helper for bumping versions via git tags.
     commit_msg_template: "[skip ci] Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
@@ -24,7 +22,7 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-    - format: binary 
+    - formats: [ 'binary' ]
       name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 # Put the packages in the artifacts dir (but it won't eval environment variables)


### PR DESCRIPTION
## Context
CI builds break because of the old version of the `goreleaser` config - need to upgrade to version `2`.

## Objective
Update the goreleaser configuration for version 2.

## References
CI failure [example](https://cd.screwdriver.cd/pipelines/16/builds/970832/steps/test-release)
```bash
22:54:52   $ curl -sL https://git.io/goreleaser | bash -s -- --snapshot
22:54:54     • only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
22:54:54     ⨯ release failed after 0s                  error=only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
```

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
