### PR TITLE
Revert "add 'brews:' section"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,11 +24,6 @@ builds:
 archives:
     - formats: [ 'binary' ]
       name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-brews:
-  -
-    name: gitversion
-    homepage: https://github.com/screwdriver-cd/gitversion
-    description: "A helper for bumping versions via git tags."
-    directory: Formula
+
 # Put the packages in the artifacts dir (but it won't eval environment variables)
 dist: /sd/workspace/artifacts/dist


### PR DESCRIPTION
Reverts screwdriver-cd/gitversion#52

There's already a `brews` section in the goreleaser configuration