### PR TITLE
use go1.24

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: golang:1.23
+    image: golang:1.24
     environment:
         GOPATH: /sd/workspace
 


### PR DESCRIPTION
## Context
Use the latest Go version.

## Objective
Since we are going to do a new release, we can as well build the tool with the latest Go version (though probably doesn't matter much).

## References
https://go.dev/doc/devel/release#go1.24.0

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
