### PR TITLE
fix: Fix CVE-2025-22871

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/screwdriver-cd/gitversion
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/abice/go-enum v0.6.1


### PR DESCRIPTION
	stdlib	go1.24.1	CVE-2025-22871	Critical	Base image
Affected Item /usr/local/bin/gitversion
Description
The net/http package improperly accepts a bare LF as a line terminator in chunked data chunk-size lines. This can permit request smuggling if a net/http server is used in conjunction with a server that incorrectly accepts a bare LF as part of a chunk-ext. Fixed State fix available
Fixed Version
1.23.8
1.24.2
Related Vulnerabilities N/A
Vendor Advisories
N/A
Remediation Details
Vulnerability found in:
Go module:
Built using Go version: go1.24.1
Vulnerable dependency: stdlib
Vulnerable Version: go1.24.1
Fixed Version(s): 1.23.8, 1.24.2
Affected Path(s):
Path: /usr/local/bin/gitversion (introduced by layer id: sha256:b26d7bb5d529db4995d31bb3c55bd0cfb53dd9e25e7c868faa2bc34408b77c0f)

Next Steps:
This vulnerability was found in the Base image used by your app container image.

Use a newer version of the base image or select a new base image that includes: upgraded go binaries for the Affected Path(s) listed above compiled with upgraded go-modules with the Fixed Version or later Update the FROM line in your Dockerfile
Then rebuild your app container image


## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
