### PR TITLE
fix: Add basic message for annotated tags

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -53,7 +53,7 @@ func (g *DefaultGit) Tags(merged bool) ([]string, error) {
 func (g *DefaultGit) Tag(tag string, annotate bool) error {
 	args := []string{"tag"}
 	if annotate {
-		args = append(args, "-a")
+		args = append(args, "-a", "-m", tag)
 	}
 	args = append(args, tag)
 

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -153,7 +153,7 @@ func TestTagAnnotated(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	expected := "v10.10.10"
 	g := gitForTest(ctrl,
-		withGitTagOutput("", "tag", "-a", expected),
+		withGitTagOutput("", "tag", "-a", "-m", expected, expected),
 	)
 
 	require.NoError(t, g.Tag(expected, true))


### PR DESCRIPTION
## Context
Annotated tags should have a message attached to it

## Objective
Adds a default message of just the new tag version to the annotated tag

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
